### PR TITLE
Adding the max graphite queue size into the construction and reading out from the config if possible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ have to to add "output\_type": "opentsdb" or "json" to your check definitions.
 As root:
 
 1. cp -R lib/sensu/extensions/\* /etc/sensu/extensions
-2. cp config\_relay.json /etc/sensu/conf.d 
+2. cp config\_relay.json /etc/sensu/conf.d
 3. Edit the values in config\_relay.json according to your environment.
 4. Restart sensu-server
 
@@ -45,9 +45,10 @@ config\_relay.json:
 ```json
 {
   "relay": {
-    "graphite": { 
+    "graphite": {
         "host": "127.0.0.1",
-        "port": 60000
+        "port": 60000,
+        "max_queue_size": 16384 # optional
     },
     "opentsdb": {
         "host": "127.0.0.1",

--- a/lib/sensu/extensions/handlers/relay.rb
+++ b/lib/sensu/extensions/handlers/relay.rb
@@ -123,7 +123,7 @@ module Sensu::Extension
 
     attr_accessor :connection, :queue
 
-    def initialize(name, host, port)
+    def initialize(name, host, port, queue_size = MAX_QUEUE_SIZE)
       @queue = []
       @connection = EM.connect(host, port, RelayConnectionHandler)
       @connection.name = name
@@ -187,7 +187,8 @@ module Sensu::Extension
         @endpoints[ep_name] = Endpoint.new(
           ep_name,
           ep_settings['host'],
-          ep_settings['port']
+          ep_settings['port'],
+          ep_settings['max_queue_size']
         )
       end
     end


### PR DESCRIPTION
This is what I have from the discussion over in https://github.com/opower/sensu-metrics-relay/issues/18. Perhaps it'll help. I haven't tested it, but I'm offering it as a way out. 